### PR TITLE
OpenTechCalendar - switch to SSL URL so calendar page works again

### DIFF
--- a/static/js/cal.js
+++ b/static/js/cal.js
@@ -1,4 +1,4 @@
-var url = "http://opentechcalendar.co.uk/api1/area/59/events.jsonp?callback=?";
+var url = "https://opentechcalendar.co.uk/api1/area/59/events.jsonp?callback=?";
 
 var mkhtml = function(entry) {
   return "<li>"


### PR DESCRIPTION
Now the main site is on HTTPS, JS calls must be to to avoid security blocks.